### PR TITLE
Add: RDS file explanation, replace large CSV with RDS file in data folder

### DIFF
--- a/code/preprocessing.R
+++ b/code/preprocessing.R
@@ -1,5 +1,5 @@
 ## Code for 3.2. Vorbereitung der Daten: Einlesen und Bereinigung
-## Creates the df_merged_final.csv file needed for the dashboard
+## Creates the df_merged_final.rds file needed for the dashboard
 
 library(sf)
 library(dplyr)
@@ -126,13 +126,15 @@ df_final <- df_baeume_final %>%
     timestamp
   )
 
-# 11. Ergebnis speichern
-if (!dir.exists("data")) dir.create("data")
-
-# Als CSV speichern (menschenlesbar, teilbar, in Excel öffnbar)
-write.csv2(df_final, "data/df_merged_final.csv", row.names = FALSE, fileEncoding = "UTF-8")
-
-# Als RDS speichern (R Data Serialization, maschinenlesbar, schnelleres Laden)
+# RDS speichern (wird im Dashboard später verwendet)
 saveRDS(df_final, "data/df_merged_final.rds")
 
+# Optional: Als CSV speichern (menschenlesbar, in Excel öffnbar, aber langsamer zu laden)
+write.csv2(df_final, "data/df_merged_final.csv", row.names = FALSE, fileEncoding = "UTF-8")
+
+# Kontrolle: Daten kurz anschauen
 cat("Fertig! Zeilen:", nrow(df_final), "| Spalten:", ncol(df_final), "\n")
+
+# Um die RDS-Datei später zu inspizieren, nutzen Sie:
+df_check <- readRDS("data/df_merged_final.rds")
+View(df_check)  # Öffnet die Tabelle in R Studio

--- a/data/df_merged_final.csv
+++ b/data/df_merged_final.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8ef99ce8bd351dd2051acf7753b103226da682e7429b642fb7f929c1f30c8d6
-size 299574054

--- a/datenbasis/daten-vorbereitung.md
+++ b/datenbasis/daten-vorbereitung.md
@@ -356,21 +356,37 @@ df_final <- df_baeume_final %>%
 ```
 - Um die App performant zu halten und unnötigen Ballast zu entfernen, reduzieren Sie die finale Tabelle auf die 7 Spalten, die für das Dashboard tatsächlich gebraucht werden.
 
-**11. Neue, vollständige Tabelle in verschiedenen Formaten speichern**
+**11. Neue, vollständige Tabelle speichern**
+
+````{margin}
+```{admonition} Was ist eine RDS-Datei?
+:class: hinweis
+
+Das native Serialisierungsformat von R, die R-Objekte (wie DataFrames) in einem komprimierten, binären Format spechiert.    
+Die Dateigröße ist wesentlich **kleiner und kompakter** als bei einer herkömmlichen CSV-Datei, wodurch sie deutlich **schneller** lädt und sich perfekt für R-Shiny und andere R-basierte Anwendungen eignet.
+```
+````
 
 ```r
-# Als CSV speichern (menschenlesbar, teilbar, in Excel öffnbar)
-write.csv2(df_final, "data/df_merged_final.csv", row.names = FALSE, fileEncoding = "UTF-8")
-
-# Als RDS speichern (R Data Serialization, maschinenlesbar, schnelleres Laden)
+# RDS speichern (wird im Dashboard später verwendet)
 saveRDS(df_final, "data/df_merged_final.rds")
 
+# Optional: Als CSV speichern (menschenlesbar, in Excel öffnbar, aber langsamer zu laden)
+write.csv2(df_final, "data/df_merged_final.csv", row.names = FALSE, fileEncoding = "UTF-8")
+
+# Kontrolle: Daten kurz anschauen
 cat("Fertig! Zeilen:", nrow(df_final), "| Spalten:", ncol(df_final), "\n")
+
+# Um die RDS-Datei später zu inspizieren, nutzen Sie:
+df_check <- readRDS("data/df_merged_final.rds")
+View(df_check)  # Öffnet die Tabelle in R Studio
 ```
 
-- Die neue Tabelle mit allen Bäumen und Bezirken speichern Sie als CSV-Datei (inklusive korrekter UTF-8-Zeichenkodierung für Sonderzeichen).
+- Die neue Tabelle mit allen Bäumen und Bezirken speichern Sie als `.rds`-Datei. Dieses Format wird später beim Bau des Dashboards verwendet.
 
-- Zusätzlich speichern Sie die Daten als .rds-Datei. Dieses R-spezifische Format lädt in R-Shiny deutlich schneller als eine herkömmliche CSV-Datei.
+- Das zusätzliche Speichern als CSV ist optional, falls Sie die Daten auch in Excel oder anderen Programmen öffnen möchten.
+
+- Mit `readRDS()` können Sie die RDS-Datei jederzeit in R Studio laden und mit `View()` inspizieren.
 
 
 Am Ende haben Sie wieder die Möglichkeit, sich den gesamten Code anzusehen, bevor Sie im nächsten Kapitel die Entwicklungsumgebung auf den Bau des Dashboards vorbereiten.
@@ -445,13 +461,17 @@ df_final <- df_baeume_final %>%
   )
 
 # 11. Ergebnis speichern
-# Als CSV speichern (menschenlesbar, teilbar, in Excel öffnbar)
-write.csv2(df_final, "data/df_merged_final.csv", row.names = FALSE, fileEncoding = "UTF-8")
-
-# Als RDS speichern (R Data Serialization, maschinenlesbar, schnelleres Laden)
+# RDS speichern (wird im Dashboard später verwendet)
 saveRDS(df_final, "data/df_merged_final.rds")
 
+# Optional: Als CSV speichern
+write.csv2(df_final, "data/df_merged_final.csv", row.names = FALSE, fileEncoding = "UTF-8")
+
 cat("Fertig! Zeilen:", nrow(df_final), "| Spalten:", ncol(df_final), "\n")
+
+# Um die RDS-Datei später zu inspizieren:
+df_check <- readRDS("data/df_merged_final.rds")
+View(df_check)
 ```
 
 ````


### PR DESCRIPTION

- Updated `datenbasis/daten-vorbereitung.md` to explain the benefits of RDS (smaller, faster, native to R), make CSV export optional, and provide code examples for saving and loading RDS files. 
- Replaced the large df_merged_final CSV file in the data folder with the smaller RDS file.