### PR TITLE
Fix: bibtex for 4.1 Janes2013

### DIFF
--- a/4_dash-prep/4.1_dashboard.md
+++ b/4_dash-prep/4.1_dashboard.md
@@ -83,6 +83,5 @@ Kurz gesagt: Ein Dashboard verwandelt Rohdaten in umsetzbare Informationen, die 
 
 ```{bibliography}
 :filter: docname in docnames
-:list: bullet
 ```
 

--- a/references.bib
+++ b/references.bib
@@ -282,13 +282,13 @@ connect to your specific data},
 	year = {2024},
 }
 
-@article{Janes2013Effective,
-  author = {Janes, Andrea and Sillitti, Alberto and Succi, Giancarlo},
-  title = {Effective dashboard design},
-  journal = {Cutter IT Journal},
-  year = {2013},
-  month = {jan},
-  note = {Published in January 2013},
-  url = {https://www.researchgate.net/publication/286996830}
-}
 
+@article{Janes2013Effective,
+author = {Janes, Andrea and Sillitti, Alberto and Succi, Giancarlo},
+year = {2013},
+month = {01},
+pages = {17-24},
+title = {Effective dashboard design},
+volume = {26},
+journal = {Cutter IT Journal}
+}


### PR DESCRIPTION
@gabo539 
I only checked one citation, and changed the bibtex by directly copying it from their citation
<img width="1300" height="546" alt="image" src="https://github.com/user-attachments/assets/727c742a-db12-4e31-b36a-b95085f37b5b" />
I have removed the style bullet as we have done it like this in [Tabelle-1](https://quadriga-dk.github.io/Tabelle-Fallstudie-1/Markdown/3_1_FairPrinzipien.html). 

We need to check all the references bibtex that are not working... Otherwise the citation style from the md file, and the config file are both correct.