### PR TITLE
Update: Reference style

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,8 +55,6 @@ html:
   use_multitoc_numbering: false
 
 sphinx:
-  extra_extensions:
-    - sphinx_apa_references
   config:
     language: de
     numfig: true

--- a/_static/quadriga.css
+++ b/_static/quadriga.css
@@ -337,21 +337,3 @@ html[data-theme='dark'] div.story > .admonition-title::after {
     color: #b876d1
 }
 
-/* Fix bibliography URL overflow — targets actual rendered HTML */
-div.citation {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    margin-bottom: 1rem;
-    overflow: hidden;
-}
-
-div.citation p,
-div.citation dd,
-div.citation .docutils {
-    overflow-wrap: break-word;
-    word-break: break-all;
-    word-wrap: break-word;
-    min-width: 0;
-    flex: 1;
-}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 jupyter-book==1.0.4
 teachbooks==0.2.3
-sphinx_apa_references==1.0
 JupyterQuiz==2.8.*
 matplotlib
 numpy


### PR DESCRIPTION
@pwalter24 asked me to change the Literatur and Citation style as same as Tabelle-4. Previously we used `sphinx apa reference `style, now it's only `bibtex_reference_style: author_year`. 

You can get a preview here: https://lam1aa.github.io/Tabelle-Fallstudie-3/4_dash-prep/4.2_tools.html